### PR TITLE
GetHandler_NonGeneric_Multithreaded_DynamicTypesAsync

### DIFF
--- a/tests/GetHandlerTests.cs
+++ b/tests/GetHandlerTests.cs
@@ -1,6 +1,10 @@
+using System.Reflection.Emit;
+using System.Reflection;
+using System;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OoLunar.AsyncEvents.Tests.Data;
+using System.Collections.Generic;
 
 namespace OoLunar.AsyncEvents.Tests
 {
@@ -35,6 +39,60 @@ namespace OoLunar.AsyncEvents.Tests
                 asyncEvent = _container.GetAsyncEvent(typeof(TestAsyncEventArgs));
                 await asyncEvent.InvokeAsync(new TestAsyncEventArgs());
             });
+        }
+
+        [TestMethod]
+        public async ValueTask GetHandler_NonGeneric_Multithreaded_DynamicTypesAsync()
+        {
+            // List to hold dynamically created types
+            List<Type> types = [];
+
+            // Create 5000 dynamic types with a unique property for each
+            for (int i = 0; i < 5000; i++)
+            {
+                types.Add(CreateDynamicType(i));
+            }
+
+            IAsyncEvent asyncEvent;
+            await Parallel.ForAsync(0, types.Count, (i, _) =>
+            {
+                AsyncEventArgs instance = Activator.CreateInstance(types[i]) as AsyncEventArgs
+                    ?? throw new TypeAccessException();
+                asyncEvent = _container.GetAsyncEvent(instance.GetType());
+                return ValueTask.CompletedTask;
+            });
+
+        }
+
+        // Create a dynamic type with a property
+        private Type CreateDynamicType(int index)
+        {
+            // Create a dynamic assembly and module
+            AssemblyName assemblyName = new AssemblyName("DynamicTypesAssembly");
+            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("MainModule");
+
+            // Define a type that inherits from BaseClass
+            TypeBuilder typeBuilder = moduleBuilder.DefineType(
+                $"DynamicType{index}",
+                TypeAttributes.Public,
+                typeof(AsyncEventArgs));
+
+            // Define a method "CustomMethod" in the dynamic type
+            MethodBuilder customMethodBuilder = typeBuilder.DefineMethod(
+                "CustomMethod",
+                MethodAttributes.Public | MethodAttributes.Virtual,
+                typeof(void),
+                Type.EmptyTypes);
+
+            ILGenerator ilGenerator = customMethodBuilder.GetILGenerator();
+            ilGenerator.EmitWriteLine($"Dynamic Type {index} custom method executed.");
+            ilGenerator.Emit(OpCodes.Ret);
+
+            // Create the type
+            Type dynamicType = typeBuilder.CreateType();
+
+            return dynamicType;
         }
     }
 }


### PR DESCRIPTION
Write an effective test case for GetHandler using dynamically created objects inheriting from AsyncEventArgs.

Use case:
The other two tests use the same type of AsyncEventArgs, which when used with `GetHandler`, simply returns the existing object. 
This aims to address this without creating 9999999 classes that implement AsyncEventArgs so that each call to `GetHandler` will not return so quickly to thoroughly test concurrency on `AsyncEventContainer` private dictionaries.